### PR TITLE
eliminate on disconnect

### DIFF
--- a/data/lavarising/functions/main.mcfunction
+++ b/data/lavarising/functions/main.mcfunction
@@ -40,6 +40,9 @@ execute if score period internal matches 2 as @e[tag=riser,limit=1] at @s run fu
 # time loop
 function lavarising:time
 
+# count players
+function lavarising:system/main/count
+
 # death checks
 ## solos
 execute if score period internal matches 2 unless score teams global matches 1.. as @a at @s if score @s player.death matches 1.. run function lavarising:system/death/solos/go

--- a/data/lavarising/functions/main.mcfunction
+++ b/data/lavarising/functions/main.mcfunction
@@ -41,7 +41,7 @@ execute if score period internal matches 2 as @e[tag=riser,limit=1] at @s run fu
 function lavarising:time
 
 # count players
-function lavarising:system/main/count
+execute if score period internal matches 2 if score eliminate_on_disconnect global matches 1.. run function lavarising:system/main/count
 
 # death checks
 ## solos

--- a/data/lavarising/functions/main.mcfunction
+++ b/data/lavarising/functions/main.mcfunction
@@ -58,8 +58,7 @@ execute if score period internal matches 2 if score teams global matches 1.. if 
 execute if score period internal matches 2 if score teams global matches 1.. if score teams_count global matches 3.. run function lavarising:system/win/teams-3/check
 
 # disconnect checks
-## disabled for now
-execute if score eliminate_on_disconnect global matches 1.. run tellraw @a ["",{"text":"[","color":"dark_gray"},{"text":"X","color":"red","bold":true},{"text":"] ","color":"dark_gray"},{"text":"This feature is disabled for now and not available.","color":"red"}]
-execute if score eliminate_on_disconnect global matches 1.. run scoreboard players set eliminate_on_disconnect global 0
 ## refer to 'eliminate_on_disconnect' in defaults
-execute if score period internal matches 2 if score eliminate_on_disconnect global matches 1.. if entity @a[scores={player.leave=1..}] run function lavarising:system/death/disconnect
+execute if score period internal matches 2 if score eliminate_on_disconnect global matches 1.. as @a if score @s player.leave matches 1.. run function lavarising:system/death/disconnect
+## reset (for people currently on the server)
+scoreboard players reset @a player.leave

--- a/data/lavarising/functions/setup/eliminate_on_disconnect/off.mcfunction
+++ b/data/lavarising/functions/setup/eliminate_on_disconnect/off.mcfunction
@@ -1,0 +1,2 @@
+scoreboard players set eliminate_on_disconnect global 0
+function lavarising:setup/sfx/off

--- a/data/lavarising/functions/setup/eliminate_on_disconnect/on.mcfunction
+++ b/data/lavarising/functions/setup/eliminate_on_disconnect/on.mcfunction
@@ -1,0 +1,2 @@
+scoreboard players set eliminate_on_disconnect global 1
+function lavarising:setup/sfx/on

--- a/data/lavarising/functions/setup/go.mcfunction
+++ b/data/lavarising/functions/setup/go.mcfunction
@@ -16,6 +16,12 @@ execute if score teams global matches 1.. run tellraw @s ["",{"text":"Teams \u00
 ## disabled
 execute unless score teams global matches 1.. run tellraw @s ["",{"text":"Teams \u0020 \u0020","hoverEvent":{"action":"show_text","contents":[{"text":"Fight to the death together! Requires adding players to red/blue (or green if 3 teams)."}]}},{"text":" ","color":"dark_gray"},{"text":"✔","color":"green","bold":true,"clickEvent":{"action":"run_command","value":"/function lavarising:setup/teams/on"}},{"text":" ","color":"dark_gray"},{"text":" [","color":"white"},{"text":"X","color":"red","bold":true},{"text":"]","color":"white"}]
 
+# eliminate on disconnect
+## enabled
+execute if score eliminate_on_disconnect global matches 1.. run tellraw @s ["",{"text":"Eliminate on disconnect \u0020 \u0020","hoverEvent":{"action":"show_text","contents":[{"text":"If a player leaves the server, upon rejoin they will be eliminated."}]}},{"text":"[","color":"white"},{"text":"✔","color":"green","bold":true},{"text":"]","color":"white"},{"text":"  ","color":"dark_gray"},{"text":"X","color":"red","bold":true,"clickEvent":{"action":"run_command","value":"/function lavarising:setup/eliminate_on_disconnect/off"}},{"text":" ","color":"dark_gray"}]
+## disabled
+execute unless score eliminate_on_disconnect global matches 1.. run tellraw @s ["",{"text":"Eliminate on disconnect \u0020 \u0020","hoverEvent":{"action":"show_text","contents":[{"text":"If a player leaves the server, upon rejoin they will be eliminated."}]}},{"text":" ","color":"dark_gray"},{"text":"✔","color":"green","bold":true,"clickEvent":{"action":"run_command","value":"/function lavarising:setup/eliminate_on_disconnect/on"}},{"text":" ","color":"dark_gray"},{"text":" [","color":"white"},{"text":"X","color":"red","bold":true},{"text":"]","color":"white"}]
+
 # rise height limit
 tellraw @s ["",{"text":"Rise height limit \u0020 \u0020","hoverEvent":{"action":"show_text","contents":[{"text":"The maximum height limit the lava can reach."}]}},{"text":" ","color":"white"},{"text":"-","color":"red","bold":true,"clickEvent":{"action":"run_command","value":"/function lavarising:setup/rise_height_limit/down"}},{"text":"  ","color":"white"},{"score":{"name":"rise_height_limit","objective":"global"}},{"text":"  ","color":"dark_gray"},{"text":"+","color":"green","bold":true,"clickEvent":{"action":"run_command","value":"/function lavarising:setup/rise_height_limit/up"}},{"text":" ","color":"dark_gray"}]
 

--- a/data/lavarising/functions/system/death/disconnect.mcfunction
+++ b/data/lavarising/functions/system/death/disconnect.mcfunction
@@ -4,10 +4,9 @@
 
 # swap gamemode
 gamemode spectator @s
-scoreboard players remove alive internal 1
 
 # announce
-tellraw @a ["",{"text":"[","color":"dark_gray"},{"text":"☠","color":"red"},{"text":"] ","color":"dark_gray"},{"selector":"@s","color":"red","bold":true},{"text":" has been eliminated!","color":"dark_red"}]
+tellraw @a ["",{"text":"[","color":"dark_gray"},{"text":"☠","color":"red"},{"text":"] ","color":"dark_gray"},{"selector":"@s","color":"red","bold":true},{"text":" has been eliminated! (left during game)","color":"dark_red"}]
 # sfx
 execute as @a at @s run playsound minecraft:entity.lightning_bolt.thunder player @s
 

--- a/data/lavarising/functions/system/death/solos/go.mcfunction
+++ b/data/lavarising/functions/system/death/solos/go.mcfunction
@@ -3,7 +3,6 @@
 
 # swap gamemode
 gamemode spectator @s
-scoreboard players remove alive internal 1
 
 # announce
 tellraw @a ["",{"text":"[","color":"dark_gray"},{"text":"☠","color":"red"},{"text":"] ","color":"dark_gray"},{"selector":"@s","color":"red","bold":true},{"text":" has been eliminated!","color":"dark_red"}]

--- a/data/lavarising/functions/system/death/solos/go.mcfunction
+++ b/data/lavarising/functions/system/death/solos/go.mcfunction
@@ -3,6 +3,7 @@
 
 # swap gamemode
 gamemode spectator @s
+execute unless score eliminate_on_disconnect global matches 1.. run scoreboard players remove alive internal 1
 
 # announce
 tellraw @a ["",{"text":"[","color":"dark_gray"},{"text":"☠","color":"red"},{"text":"] ","color":"dark_gray"},{"selector":"@s","color":"red","bold":true},{"text":" has been eliminated!","color":"dark_red"}]

--- a/data/lavarising/functions/system/death/teams/go_blue.mcfunction
+++ b/data/lavarising/functions/system/death/teams/go_blue.mcfunction
@@ -4,8 +4,6 @@
 
 # swap gamemode
 gamemode spectator @s
-scoreboard players remove alive internal 1
-scoreboard players remove alive_blue internal 1
 
 # announce
 tellraw @a ["",{"text":"[","color":"dark_gray"},{"text":"☠","color":"red"},{"text":"] ","color":"dark_gray"},{"selector":"@s","color":"blue","bold":true},{"text":" has been eliminated!","color":"dark_red"}]

--- a/data/lavarising/functions/system/death/teams/go_blue.mcfunction
+++ b/data/lavarising/functions/system/death/teams/go_blue.mcfunction
@@ -4,6 +4,8 @@
 
 # swap gamemode
 gamemode spectator @s
+execute unless score eliminate_on_disconnect global matches 1.. run scoreboard players remove alive internal 1
+execute unless score eliminate_on_disconnect global matches 1.. run scoreboard players remove alive_blue internal 1
 
 # announce
 tellraw @a ["",{"text":"[","color":"dark_gray"},{"text":"☠","color":"red"},{"text":"] ","color":"dark_gray"},{"selector":"@s","color":"blue","bold":true},{"text":" has been eliminated!","color":"dark_red"}]

--- a/data/lavarising/functions/system/death/teams/go_green.mcfunction
+++ b/data/lavarising/functions/system/death/teams/go_green.mcfunction
@@ -4,6 +4,8 @@
 
 # swap gamemode
 gamemode spectator @s
+execute unless score eliminate_on_disconnect global matches 1.. run scoreboard players remove alive internal 1
+execute unless score eliminate_on_disconnect global matches 1.. run scoreboard players remove alive_green internal 1
 
 # announce
 tellraw @a ["",{"text":"[","color":"dark_gray"},{"text":"☠","color":"red"},{"text":"] ","color":"dark_gray"},{"selector":"@s","color":"green","bold":true},{"text":" has been eliminated!","color":"dark_red"}]

--- a/data/lavarising/functions/system/death/teams/go_green.mcfunction
+++ b/data/lavarising/functions/system/death/teams/go_green.mcfunction
@@ -4,8 +4,6 @@
 
 # swap gamemode
 gamemode spectator @s
-scoreboard players remove alive internal 1
-scoreboard players remove alive_green internal 1
 
 # announce
 tellraw @a ["",{"text":"[","color":"dark_gray"},{"text":"☠","color":"red"},{"text":"] ","color":"dark_gray"},{"selector":"@s","color":"green","bold":true},{"text":" has been eliminated!","color":"dark_red"}]

--- a/data/lavarising/functions/system/death/teams/go_red.mcfunction
+++ b/data/lavarising/functions/system/death/teams/go_red.mcfunction
@@ -4,8 +4,6 @@
 
 # swap gamemode
 gamemode spectator @s
-scoreboard players remove alive internal 1
-scoreboard players remove alive_red internal 1
 
 # announce
 tellraw @a ["",{"text":"[","color":"dark_gray"},{"text":"☠","color":"red"},{"text":"] ","color":"dark_gray"},{"selector":"@s","color":"red","bold":true},{"text":" has been eliminated!","color":"dark_red"}]

--- a/data/lavarising/functions/system/death/teams/go_red.mcfunction
+++ b/data/lavarising/functions/system/death/teams/go_red.mcfunction
@@ -4,6 +4,8 @@
 
 # swap gamemode
 gamemode spectator @s
+execute unless score eliminate_on_disconnect global matches 1.. run scoreboard players remove alive internal 1
+execute unless score eliminate_on_disconnect global matches 1.. run scoreboard players remove alive_red internal 1
 
 # announce
 tellraw @a ["",{"text":"[","color":"dark_gray"},{"text":"☠","color":"red"},{"text":"] ","color":"dark_gray"},{"selector":"@s","color":"red","bold":true},{"text":" has been eliminated!","color":"dark_red"}]

--- a/data/lavarising/functions/system/main/count.mcfunction
+++ b/data/lavarising/functions/system/main/count.mcfunction
@@ -1,0 +1,16 @@
+# LAVARISING player count
+
+
+## solos
+scoreboard players set alive internal 0
+execute as @a[gamemode=survival] run scoreboard players add alive internal 1
+## teams
+scoreboard players set alive_red internal 0
+scoreboard players set alive_blue internal 0
+scoreboard players set alive_green internal 0
+execute as @a[gamemode=survival,team=red] run scoreboard players add alive_red internal 1
+execute as @a[gamemode=survival,team=blue] run scoreboard players add alive_blue internal 1
+execute as @a[gamemode=survival,team=green] run scoreboard players add alive_green internal 1
+## debug!
+execute if score debug internal matches 77 run scoreboard players operation alive internal += 1 internal
+execute if score debug internal matches 77 run scoreboard players operation alive_blue internal += 1 internal

--- a/data/lavarising/functions/system/period/main.mcfunction
+++ b/data/lavarising/functions/system/period/main.mcfunction
@@ -11,19 +11,7 @@ execute if score legacy global matches 1.. run tp @e[tag=riser,limit=1] 0 0 0
 execute unless score legacy global matches 1.. run tp @e[tag=riser,limit=1] 0 -64 0
 
 # count players
-## solos
-scoreboard players set alive internal 0
-execute as @a[gamemode=survival] run scoreboard players add alive internal 1
-## teams
-scoreboard players set alive_red internal 0
-scoreboard players set alive_blue internal 0
-scoreboard players set alive_green internal 0
-execute as @a[gamemode=survival,team=red] run scoreboard players add alive_red internal 1
-execute as @a[gamemode=survival,team=blue] run scoreboard players add alive_blue internal 1
-execute as @a[gamemode=survival,team=green] run scoreboard players add alive_green internal 1
-## debug!
-execute if score debug internal matches 77 run scoreboard players operation alive internal += 1 internal
-execute if score debug internal matches 77 run scoreboard players operation alive_blue internal += 1 internal
+function lavarising:system/main/count
 
 # announce
 title @a title ["",{"text":"LAVA RISING","color":"red","bold":true}]

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
-        "description": "Lava Rising for 1.19\n\u00A762022.1202 \u00A7r• \u00A7bplexion.dev",
+        "description": "Lava Rising for 1.19\n\u00A762022.1210 \u00A7r• \u00A7bplexion.dev",
         "pack_format": 10
     }
 }


### PR DESCRIPTION
adds previously mentioned elimination on disconnect functionality (if enabled, disabled by default).

#### changes
- player count is now tracked every tick (to account for player leave resulting in inaccurate player count)
  - this functionality only occurs if enabled
- on disconnect (tracked with `player.leave`), you will be eliminated on rejoin

and that's it, a lot simpler than i had thought.